### PR TITLE
Event handler priorities

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/EventListener/AuthenticationListener.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/EventListener/AuthenticationListener.php
@@ -76,8 +76,8 @@ class AuthenticationListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            FOSUserEvents::SECURITY_IMPLICIT_LOGIN => 'onSecurityImplicitLogin',
-            SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
+            FOSUserEvents::SECURITY_IMPLICIT_LOGIN => array('onSecurityImplicitLogin', 255),
+            SecurityEvents::INTERACTIVE_LOGIN => array('onSecurityInteractiveLogin', 255),
         );
     }
 


### PR DESCRIPTION
While logging in, the `LastLoginListener` tries to update the `lastLogin` using the `DelegatingUserManager`. However, the `$currentUser` in the `UserDiscriminator` isn't set - the event which sets this is scheduled to run after. 

I've given the subscribed events in `AuthenticationListener` the maximum possible priority so that they'll run before other events which might be trying to use the `UserDiscriminator`. 

I don't know whether there'd be a case where other subscribers would need to be called before these. If there might be, the priority of these events may need reducing. 
