### PR TITLE
Removed session caching from the UserDiscriminator

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/EventListener/RequestListener.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/EventListener/RequestListener.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface;
-use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminator;
 
 /**
  * Tries to determine the current user-system.
@@ -24,11 +23,6 @@ use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminator;
  */
 class RequestListener
 {
-    /**
-     * @var SessionInterface
-     */
-    protected $session;
-
     /**
      * @var UserDiscriminatorInterface
      */
@@ -43,9 +37,8 @@ class RequestListener
      * @param SessionInterface           $session
      * @param UserDiscriminatorInterface $userDiscriminator
      */
-    public function __construct(SessionInterface $session, UserDiscriminatorInterface $userDiscriminator)
+    public function __construct(UserDiscriminatorInterface $userDiscriminator)
     {
-        $this->session = $session;
         $this->userDiscriminator = $userDiscriminator;
         $this->users = array();
     }
@@ -66,12 +59,6 @@ class RequestListener
     {
         // Already set
         if (null !== $this->userDiscriminator->getCurrentUser()) {
-            return;
-        }
-
-        if ($name = $this->session->get(UserDiscriminator::SESSION_NAME)) {
-            $this->userDiscriminator->setCurrentUser($name);
-
             return;
         }
 

--- a/src/Rollerworks/Bundle/MultiUserBundle/Model/UserDiscriminator.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Model/UserDiscriminator.php
@@ -11,20 +11,11 @@
 
 namespace Rollerworks\Bundle\MultiUserBundle\Model;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class UserDiscriminator implements UserDiscriminatorInterface
 {
-    const SESSION_NAME = 'rollerworks_multi_user.user_discriminator.current';
-
-    /**
-     * @var SessionInterface
-     */
-    protected $session;
-
     /**
      * @var UserConfig[]
      */
@@ -39,10 +30,8 @@ class UserDiscriminator implements UserDiscriminatorInterface
      * @param SessionInterface $session
      * @param UserConfig[]     $users
      */
-    public function __construct(SessionInterface $session, array $users = null)
+    public function __construct(array $users = null)
     {
-        $this->session = $session;
-
         if ($users) {
             foreach ($users as $name => $user) {
                 $this->addUser($name, $user);
@@ -63,10 +52,6 @@ class UserDiscriminator implements UserDiscriminatorInterface
      */
     public function getCurrentUserConfig()
     {
-        if (!$this->currentUser) {
-            $this->currentUser = $this->session->get(static::SESSION_NAME);
-        }
-
         if (!isset($this->users[$this->currentUser])) {
             return null;
         }
@@ -77,17 +62,13 @@ class UserDiscriminator implements UserDiscriminatorInterface
     /**
      * {@inheritDoc}
      */
-    public function setCurrentUser($name, $persist = false)
+    public function setCurrentUser($name)
     {
         if (!isset($this->users[$name])) {
             throw new \LogicException(sprintf('Impossible to set the user discriminator, because "%s" is not present in the users list.', $name));
         }
 
         $this->currentUser = $name;
-
-        if ($persist) {
-            $this->session->set(static::SESSION_NAME, $name);
-        }
     }
 
     /**
@@ -95,10 +76,6 @@ class UserDiscriminator implements UserDiscriminatorInterface
      */
     public function getCurrentUser()
     {
-        if (!$this->currentUser) {
-            $this->currentUser = $this->session->get(static::SESSION_NAME);
-        }
-
         if (!isset($this->users[$this->currentUser])) {
             return null;
         }

--- a/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
@@ -24,7 +24,6 @@
 
         <service id="rollerworks_multi_user.listener.request" class="Rollerworks\Bundle\MultiUserBundle\EventListener\RequestListener">
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-4" />
-            <argument type="service" id="session" />
             <argument type="service" id="rollerworks_multi_user.user_discriminator" />
         </service>
 

--- a/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/services.xml
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/services.xml
@@ -11,7 +11,7 @@
 
     <services>
         <service id="rollerworks_multi_user.user_discriminator" class="%rollerworks_multi_user.user_discriminator.class%">
-            <argument type="service" id="session" />
+            <argument type="collection" />
         </service>
 
         <service id="rollerworks_multi_user.user_manager.delegating" class="Rollerworks\Bundle\MultiUserBundle\Model\DelegatingUserManager" public="false">

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Listener/RequestListenerTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Listener/RequestListenerTest.php
@@ -98,39 +98,12 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->onKernelRequest($event);
     }
 
-    public function testAlreadySetBySession()
-    {
-        $this->session->expects($this->once())->method('get')->with(UserDiscriminator::SESSION_NAME)->will($this->returnValue('user2'));
-
-        $matcher1 = $this->getMock('Symfony\Component\HttpFoundation\RequestMatcherInterface');
-        $matcher1->expects($this->never())->method('matches')->will($this->returnValue(false));
-
-        $matcher2 = $this->getMock('Symfony\Component\HttpFoundation\RequestMatcherInterface');
-        $matcher2->expects($this->never())->method('matches')->will($this->returnValue(true));
-
-        $this->listener->addUser('user1', $matcher1);
-        $this->listener->addUser('user2', $matcher2);
-
-        $request = new Request();
-
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
-        $event->expects($this->never())->method('getRequest')->will($this->returnValue($request));
-
-        $this->userDiscriminator->expects($this->once())->method('setCurrentUser')->with('user2');
-        $this->userDiscriminator->expects($this->any())->method('getCurrentUser')->will($this->returnValue(null));
-
-        $this->listener->onKernelRequest($event);
-    }
-
     protected function setUp()
     {
-        $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')
-                ->getMock();
-
         $this->userDiscriminator = $this->getMockBuilder('Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminator')
                 ->disableOriginalConstructor()->getMock();
 
-        $this->listener = new RequestListener($this->session, $this->userDiscriminator);
+        $this->listener = new RequestListener($this->userDiscriminator);
     }
 
 }

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Model/UserDiscriminatorTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Model/UserDiscriminatorTest.php
@@ -33,8 +33,6 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->disableOriginalConstructor()->getMock();
-
         $userManager = $this->getMock('FOS\UserBundle\Model\UserManagerInterface');
         $groupManager = $this->getMock('FOS\UserBundle\Model\GroupManagerInterface');
         /** @var \FOS\UserBundle\Model\UserManagerInterface $userManager */
@@ -45,7 +43,7 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
         /** @var \FOS\UserBundle\Model\UserManagerInterface $userManager2 */
         $config2 = new UserConfig('acme_user', 'acme_user_route', $userManager2, $groupManager2);
 
-        $this->discriminator = new UserDiscriminator($this->session, array('user1' => $config, 'user2' => $config2));
+        $this->discriminator = new UserDiscriminator(array('user1' => $config, 'user2' => $config2));
         $this->users = array('user1' => $config, 'user2' => $config2);
     }
 
@@ -60,29 +58,5 @@ class UserDiscriminatorTest extends \PHPUnit_Framework_TestCase
         $this->discriminator->setCurrentUser('user2');
         $this->assertEquals('user2', $this->discriminator->getCurrentUser());
         $this->assertSame($this->users['user2'], $this->discriminator->getCurrentUserConfig());
-    }
-
-    public function testSetClassPersist()
-    {
-        $this->session->expects($this->exactly(1))->method('set')->with(UserDiscriminator::SESSION_NAME, 'user2');
-        $this->discriminator->setCurrentUser('user2', true);
-    }
-
-    public function testGetUserDefault()
-    {
-        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME, null)->will($this->onConsecutiveCalls(null));
-        $this->assertNull($this->discriminator->getCurrentUser());
-    }
-
-    public function testGetUserConfigDefault()
-    {
-        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME, null)->will($this->onConsecutiveCalls(null));
-        $this->assertNull($this->discriminator->getCurrentUserConfig());
-    }
-
-    public function testGetClassStored()
-    {
-        $this->session->expects($this->exactly(1))->method('get')->with(UserDiscriminator::SESSION_NAME, null)->will($this->onConsecutiveCalls('user2'));
-        $this->assertEquals('user2', $this->discriminator->getCurrentUser());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes, constructor of UserDiscriminator has changed |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none, related to #12 |

This removes the session-cache from the UserDiscriminator,
first the UserDiscriminator should not cache this and second because it gives some issues when the session-data is shared between users.

Caching of the discriminated user-system will be reintroduced in another PR, but must be enabled explicitly then.
Which will also will introduce a new event 'USER_DISCRIMINATED' to inform that the active user-system has changed.
