### PR TITLE
fixed overwriting of user-system configuration when not set explicitly

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Configuration.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Configuration.php
@@ -120,7 +120,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('security')
-                    ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('login')
                             ->children()
@@ -141,7 +140,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('profile')
-                    ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->children()
                         ->arrayNode('form')
@@ -174,7 +172,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('registration')
-                    ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->children()
                         ->arrayNode('confirmation')
@@ -227,7 +224,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('resetting')
-                    ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->children()
                         ->integerNode('token_ttl')->defaultValue(86400)->end()
@@ -278,7 +274,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('change_password')
-                    ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->children()
                         ->arrayNode('form')
@@ -308,10 +303,8 @@ class Configuration implements ConfigurationInterface
     final public function addServiceSection(ArrayNodeDefinition $node)
     {
         $node
-            ->addDefaultsIfNotSet()
             ->children()
                 ->arrayNode('service')
-                    ->addDefaultsIfNotSet()
                         ->children()
                             ->scalarNode('mailer')->defaultValue('fos_user.mailer.default')->end()
                             ->scalarNode('email_canonicalizer')->defaultValue('fos_user.util.canonicalizer.default')->end()

--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
@@ -86,6 +86,13 @@ class UserServicesFactory
             )
         ));
 
+        // Ensure the service section is always set
+        // This can not be done automatically because then the app-config
+        // will overwrite it with the defaults again.
+        if (!isset($config[0]['service'])) {
+            $config[0]['service'] = array();
+        }
+
         $config = $this->processConfiguration($config);
 
         $this->servicePrefix = ($config['services_prefix'] ?: $name);
@@ -185,6 +192,7 @@ class UserServicesFactory
      */
     protected function createFormService(ContainerBuilder $container, $type, array $config, Definition $user, $modelRef = null)
     {
+        // Register the form-factory, this is only to be used for user-specific forms
         if ('resetting' !== $type) {
             $container->setDefinition(sprintf('%s.%s.form.factory', $this->servicePrefix, $type), new DefinitionDecorator('rollerworks_multi_user.abstract.form.factory'))
             ->replaceArgument(1, sprintf('%%%s.%s.form.name%%', $this->servicePrefix, $type))

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
@@ -156,6 +156,10 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
 
                 'profile' => false,
                 'change_password' => false,
+
+                'confirmation' => array(),
+                'registration' => array(),
+                'resetting' => array(),
             )
         );
 
@@ -198,6 +202,10 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
 
                 'profile' => false,
                 'change_password' => false,
+
+                'confirmation' => array(),
+                'registration' => array(),
+                'resetting' => array(),
             )
         );
 
@@ -244,6 +252,10 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
 
                 'profile' => false,
                 'change_password' => false,
+
+                'confirmation' => array(),
+                'registration' => array(),
+                'resetting' => array(),
             )
         );
 
@@ -280,6 +292,10 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
 
                 'profile' => false,
                 'change_password' => false,
+
+                'confirmation' => array(),
+                'registration' => array(),
+                'resetting' => array(),
             )
         );
 
@@ -296,7 +312,7 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTemplateConfigEqual('RollerworksMultiUserBundle:UserBundle/Resetting:email.txt.twig', 'acme_user', 'resetting', 'email', $def);
     }
 
-    public function testProfileConfiguration()
+    public function testProfileConfigurationDefaults()
     {
         $factory = new UserServicesFactory($this->containerBuilder);
 
@@ -310,6 +326,8 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
                 'registration' => false,
                 'resetting' => false,
                 'change_password' => false,
+
+                'profile' => array(),
             )
         );
 
@@ -351,6 +369,70 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testProfileConfiguration()
+    {
+        $factory = new UserServicesFactory($this->containerBuilder);
+
+        $config = array(
+            array(
+                'path' => '/',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                'services_prefix' => 'acme_user',
+                'routes_prefix' => 'acme_user',
+
+                'registration' => false,
+                'resetting' => false,
+                'change_password' => false,
+
+                'profile' => array(
+                    'form' => array(
+                        'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type\ProfileType',
+                        'type' => 'acme_user_profile',
+                        'name' => 'acme_user_profile_form',
+                        'validation_groups' => array('Profile')
+                    )
+                )
+            )
+        );
+
+        $factory->create('acme', $config);
+
+        $this->assertTrue($this->containerBuilder->hasAlias('acme_user.user_manager'));
+        $this->assertTrue($this->containerBuilder->hasAlias('acme_user.group_manager'));
+
+        $this->assertTrue($this->containerBuilder->hasDefinition('rollerworks_multi_user.user_system.acme'));
+
+        $def = $this->containerBuilder->getDefinition('acme_user.user_manager.default');
+        $this->assertEquals(new Reference('rollerworks_multi_user.acme_user.model_manager'), $def->getArgument(3));
+        $this->assertEquals('%acme_user.model.user.class%', $def->getArgument(4));
+
+        $def = $this->containerBuilder->getDefinition('rollerworks_multi_user.user_system.acme');
+        $this->assertEquals('Rollerworks\Bundle\MultiUserBundle\Model\UserConfig', $def->getClass());
+        $this->assertEquals(array(array('alias' => 'acme', 'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User', 'path' => '/', 'host' => null)), $def->getTag('rollerworks_multi_user.user_system'));
+
+        if (version_compare(Kernel::VERSION, '2.3.0', '>=')) {
+            $this->assertTrue($def->isLazy());
+        }
+
+        $expected = array(
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type\ProfileType',
+            'type' => 'acme_user_profile',
+            'name' => 'acme_user_profile_form',
+            'validation_groups' => array('Profile'),
+        );
+
+        $this->assertFormDefinitionEqual($expected, 'acme_user', 'profile', $def);
+
+        $expected = array(
+            'edit' => 'RollerworksMultiUserBundle:UserBundle/Profile:edit.html.twig',
+            'show' => 'RollerworksMultiUserBundle:UserBundle/Profile:show.html.twig',
+        );
+
+        foreach ($expected as $name => $resource) {
+            $this->assertTemplateConfigEqual($resource, 'acme_user', 'profile', $name, $def);
+        }
+    }
+
     public function testRegistrationConfiguration()
     {
         $factory = new UserServicesFactory($this->containerBuilder);
@@ -365,6 +447,7 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
                 'profile' => false,
                 'resetting' => false,
                 'change_password' => false,
+                'registration' => array(),
             )
         );
 
@@ -420,6 +503,7 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
                 'profile' => false,
                 'registration' => false,
                 'change_password' => false,
+                'resetting' => array(),
             )
         );
 
@@ -496,6 +580,7 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
                 'profile' => false,
                 'registration' => false,
                 'resetting' => false,
+                'change_password' => array(),
             )
         );
 

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Stub/Form/Type/ProfileType.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Stub/Form/Type/ProfileType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type;
+
+use FOS\UserBundle\Form\Type\ProfileFormType;
+
+class ProfileType extends ProfileFormType
+{
+    public function getName()
+    {
+        return 'acme_user_profile';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes, sections are no longer automatically set |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12 |
| License | MIT |

This fixes the overwriting of user-system configuration with the defaults when passing in the app-config.

Note. profile, resetting and the like are no longer automatically enabled, these must be set explicitly.
Pass-in an empty array to trigger there defaults.
