### PR TITLE
Add discriminated events dispatcher

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,7 +39,7 @@
             <exclude>
                 <directory>./vendor</directory>
                 <directory>./src/Resources</directory>
-                <directory>./tests/Rollerworks/Bundle/MultiUserBundle/Tests/Fixtures</directory>
+                <directory>./tests/</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/scripts/generate-events.php
+++ b/scripts/generate-events.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    throw new \RuntimeException('Did not find vendor/autoload.php. Please Install vendors using command: composer.phar install --dev');
+}
+
+/**
+ * @var $loader ClassLoader
+ */
+$loader = require_once __DIR__ . '/../vendor/autoload.php';
+
+$eventsClass = new \ReflectionClass('FOS\UserBundle\FOSUserEvents');
+$events = $eventsClass->getConstants();
+
+function underscoreToCamelCase($string)
+{
+    $string = strtolower($string);
+
+    return preg_replace_callback('/_([a-z])/', function ($c) {
+        return strtoupper($c[1]);
+    }, $string);
+}
+
+$date = date('Y-m-d');
+
+echo <<<EOT
+
+    // dispatchers and event-subscriber list is generated using scripts/generate-events.php
+    // last updated on $date
+
+EOT;
+
+foreach ($events as $event => $eventName) {
+
+    $event = ucfirst(underscoreToCamelCase($event));
+    $eventName = substr($eventName, 8);
+
+echo <<<EOT
+
+    public function dispatch$event(Event \$e)
+    {
+        if (\$userSys = \$this->userDiscriminator->getCurrentUser()) {
+            \$this->eventDispatcher->dispatch(\$userSys . '$eventName', \$e);
+        }
+    }
+
+EOT;
+}
+
+echo <<<EOT
+
+    /**
+     * Subscribes to all events defined in FOS\UserBundle\FOSUserEvents.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+
+EOT;
+
+foreach ($events as $event => $eventName) {
+
+    $eventFunc = ucfirst(underscoreToCamelCase($event));
+
+echo <<<EOT
+            FOSUserEvents::$event => 'dispatch$eventFunc',
+
+EOT;
+}
+
+echo <<<EOT
+        );
+    }
+EOT;

--- a/src/Rollerworks/Bundle/MultiUserBundle/EventListener/EventDiscriminator.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/EventListener/EventDiscriminator.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\EventListener;
+
+use FOS\UserBundle\FOSUserEvents;
+use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class EventDiscriminator implements EventSubscriberInterface
+{
+    /**
+     * @var UserDiscriminatorInterface
+     */
+    private $userDiscriminator;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param UserDiscriminatorInterface $userDiscriminator
+     * @param EventDispatcherInterface   $eventDispatcher
+     */
+    public function __construct(UserDiscriminatorInterface $userDiscriminator, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->userDiscriminator = $userDiscriminator;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    // dispatchers and event-subscriber list is generated using scripts/generate-events.php
+    // last updated on 2014-03-06
+
+    public function dispatchChangePasswordInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.change_password.edit.initialize', $e);
+        }
+    }
+
+    public function dispatchChangePasswordSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.change_password.edit.success', $e);
+        }
+    }
+
+    public function dispatchChangePasswordCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.change_password.edit.completed', $e);
+        }
+    }
+
+    public function dispatchGroupCreateInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.create.initialize', $e);
+        }
+    }
+
+    public function dispatchGroupCreateSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.create.success', $e);
+        }
+    }
+
+    public function dispatchGroupCreateCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.create.completed', $e);
+        }
+    }
+
+    public function dispatchGroupDeleteCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.delete.completed', $e);
+        }
+    }
+
+    public function dispatchGroupEditInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.edit.initialize', $e);
+        }
+    }
+
+    public function dispatchGroupEditSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.edit.success', $e);
+        }
+    }
+
+    public function dispatchGroupEditCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.group.edit.completed', $e);
+        }
+    }
+
+    public function dispatchProfileEditInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.profile.edit.initialize', $e);
+        }
+    }
+
+    public function dispatchProfileEditSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.profile.edit.success', $e);
+        }
+    }
+
+    public function dispatchProfileEditCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.profile.edit.completed', $e);
+        }
+    }
+
+    public function dispatchRegistrationInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.registration.initialize', $e);
+        }
+    }
+
+    public function dispatchRegistrationSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.registration.success', $e);
+        }
+    }
+
+    public function dispatchRegistrationCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.registration.completed', $e);
+        }
+    }
+
+    public function dispatchRegistrationConfirm(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.registration.confirm', $e);
+        }
+    }
+
+    public function dispatchRegistrationConfirmed(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.registration.confirmed', $e);
+        }
+    }
+
+    public function dispatchResettingResetInitialize(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.resetting.reset.initialize', $e);
+        }
+    }
+
+    public function dispatchResettingResetSuccess(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.resetting.reset.success', $e);
+        }
+    }
+
+    public function dispatchResettingResetCompleted(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.resetting.reset.completed', $e);
+        }
+    }
+
+    public function dispatchSecurityImplicitLogin(Event $e)
+    {
+        if ($userSys = $this->userDiscriminator->getCurrentUser()) {
+            $this->eventDispatcher->dispatch($userSys . '.security.implicit_login', $e);
+        }
+    }
+
+    /**
+     * Subscribes to all events defined in FOS\UserBundle\FOSUserEvents.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::CHANGE_PASSWORD_INITIALIZE => 'dispatchChangePasswordInitialize',
+            FOSUserEvents::CHANGE_PASSWORD_SUCCESS => 'dispatchChangePasswordSuccess',
+            FOSUserEvents::CHANGE_PASSWORD_COMPLETED => 'dispatchChangePasswordCompleted',
+            FOSUserEvents::GROUP_CREATE_INITIALIZE => 'dispatchGroupCreateInitialize',
+            FOSUserEvents::GROUP_CREATE_SUCCESS => 'dispatchGroupCreateSuccess',
+            FOSUserEvents::GROUP_CREATE_COMPLETED => 'dispatchGroupCreateCompleted',
+            FOSUserEvents::GROUP_DELETE_COMPLETED => 'dispatchGroupDeleteCompleted',
+            FOSUserEvents::GROUP_EDIT_INITIALIZE => 'dispatchGroupEditInitialize',
+            FOSUserEvents::GROUP_EDIT_SUCCESS => 'dispatchGroupEditSuccess',
+            FOSUserEvents::GROUP_EDIT_COMPLETED => 'dispatchGroupEditCompleted',
+            FOSUserEvents::PROFILE_EDIT_INITIALIZE => 'dispatchProfileEditInitialize',
+            FOSUserEvents::PROFILE_EDIT_SUCCESS => 'dispatchProfileEditSuccess',
+            FOSUserEvents::PROFILE_EDIT_COMPLETED => 'dispatchProfileEditCompleted',
+            FOSUserEvents::REGISTRATION_INITIALIZE => 'dispatchRegistrationInitialize',
+            FOSUserEvents::REGISTRATION_SUCCESS => 'dispatchRegistrationSuccess',
+            FOSUserEvents::REGISTRATION_COMPLETED => 'dispatchRegistrationCompleted',
+            FOSUserEvents::REGISTRATION_CONFIRM => 'dispatchRegistrationConfirm',
+            FOSUserEvents::REGISTRATION_CONFIRMED => 'dispatchRegistrationConfirmed',
+            FOSUserEvents::RESETTING_RESET_INITIALIZE => 'dispatchResettingResetInitialize',
+            FOSUserEvents::RESETTING_RESET_SUCCESS => 'dispatchResettingResetSuccess',
+            FOSUserEvents::RESETTING_RESET_COMPLETED => 'dispatchResettingResetCompleted',
+            FOSUserEvents::SECURITY_IMPLICIT_LOGIN => 'dispatchSecurityImplicitLogin',
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
@@ -49,5 +49,11 @@
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="rollerworks_multi_user.user_discriminator" />
         </service>
+
+        <service id="rollerworks_multi_user.listener.events" class="Rollerworks\Bundle\MultiUserBundle\EventListener\EventDiscriminator">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="rollerworks_multi_user.user_discriminator" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
     </services>
 </container>

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/EventListener/EventDiscriminatorTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/EventListener/EventDiscriminatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\EventListener;
+
+use Rollerworks\Bundle\MultiUserBundle\EventListener\EventDiscriminator;
+use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface;
+use Symfony\Component\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class EventDiscriminatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UserDiscriminatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $userDiscriminator;
+
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    private static $events;
+
+    /**
+     * @dataProvider getEvents
+     */
+    public function testDispatchEventWithActiveUserSystem($fosEvent, $method, $eventName)
+    {
+        $this->userDiscriminator->expects($this->once())
+            ->method('getCurrentUser')
+            ->will($this->returnValue('acme_user'));
+
+        $subscriber = $this->getMock('Rollerworks\Bundle\MultiUserBundle\Tests\EventListener\MyEventSubscriber');
+        $subscriber->staticExpects($this->atLeastOnce())
+            ->method('getSubscribedEvents')
+            ->will($this->returnValue(array($eventName => 'myFunc')));
+
+        $my = $this;
+
+        $subscriber->expects($this->once())
+            ->method('myFunc')
+            ->with(
+                $this->isInstanceOf('Symfony\Component\EventDispatcher\Event')
+            )
+            ->will($this->onConsecutiveCalls(function ($e) use ($my, $method) {
+                $my->assertInstanceOf('Rollerworks\Bundle\MultiUserBundle\Tests\EventListener\Event', $e);
+                $my->assertEquals($method, $e->getMethod());
+            }));
+
+        $this->eventDispatcher->addSubscriber(new EventDiscriminator($this->userDiscriminator, $this->eventDispatcher));
+        $this->eventDispatcher->addSubscriber($subscriber);
+        $this->eventDispatcher->dispatch($fosEvent, new Event($method));
+    }
+
+    /**
+     * @dataProvider getEvents
+     */
+    public function testDispatcherOnlyForActive($fosEvent, $method, $eventName)
+    {
+        $this->userDiscriminator->expects($this->once())
+            ->method('getCurrentUser')
+            ->will($this->returnValue('acme_admin'));
+
+        $subscriber = $this->getMock('Rollerworks\Bundle\MultiUserBundle\Tests\EventListener\MyEventSubscriber');
+        $subscriber->staticExpects($this->atLeastOnce())
+            ->method('getSubscribedEvents')
+            ->will($this->returnValue(array($eventName => 'myFunc')));
+
+        $subscriber->expects($this->never())->method('myFunc');
+
+        $this->eventDispatcher->addSubscriber(new EventDiscriminator($this->userDiscriminator, $this->eventDispatcher));
+        $this->eventDispatcher->addSubscriber($subscriber);
+        $this->eventDispatcher->dispatch($fosEvent, new Event($method));
+    }
+
+    /**
+     * @dataProvider getEvents
+     */
+    public function testDoesNotDispatcherWhenNoUserSysIsActive($fosEvent, $method, $eventName)
+    {
+        $subscriber = $this->getMock('Rollerworks\Bundle\MultiUserBundle\Tests\EventListener\MyEventSubscriber');
+        $subscriber->staticExpects($this->atLeastOnce())
+            ->method('getSubscribedEvents')
+            ->will($this->returnValue(array($eventName => 'myFunc')));
+
+        $subscriber->expects($this->never())->method('myFunc');
+
+        $this->eventDispatcher->addSubscriber(new EventDiscriminator($this->userDiscriminator, $this->eventDispatcher));
+        $this->eventDispatcher->addSubscriber($subscriber);
+        $this->eventDispatcher->dispatch($fosEvent, new Event($method));
+    }
+
+    public static function getEvents()
+    {
+        if (null !== self::$events) {
+            return self::$events;
+        }
+
+        $eventsClass = new \ReflectionClass('FOS\UserBundle\FOSUserEvents');
+        $events = $eventsClass->getConstants();
+        $finalEvents = array();
+
+        foreach ($events as $event => $eventValue) {
+            $finalEvents[] = array(
+                $eventValue,
+                ucfirst(self::underscoreToCamelCase($event)),
+                'acme_user' . substr($eventValue, 8)
+            );
+        }
+
+        self::$events = $finalEvents;
+
+        return $finalEvents;
+    }
+
+    protected function setUp()
+    {
+        $this->userDiscriminator = $this->getMock('Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface');
+        $this->eventDispatcher = new EventDispatcher();
+    }
+
+    protected static function underscoreToCamelCase($string)
+    {
+        $string = strtolower($string);
+
+        return preg_replace_callback('/_([a-z])/', function ($c) {
+            return strtoupper($c[1]);
+        }, $string);
+    }
+}
+
+interface MyEventSubscriber extends EventSubscriberInterface
+{
+    public function myFunc($func, $event);
+}
+
+class Event extends BaseEvent
+{
+    private $method;
+
+    public function __construct($method)
+    {
+        $this->method = $method;
+    }
+
+    public function getMethod()
+    {
+        return $this->method;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets | GH-14 |
| License | MIT |
| Doc PR |  |

The EventDiscriminator re-dispatches FOSUserBundle events for the current usersystem. This idea was originally proposed by @dramos. But this implementation uses less magic.

**Todo**
- [x] Add tests
- [ ] Update documentation
