### PR TITLE
Make the original FOSUserBundle commands work

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,12 @@ You need at least Symfony 2.2, FOSUserBundle 2.0 and the Composer package manage
 Most of the configuration and creating of classes is kept in sync with the FOSUserBundle,
 so if something is not described in detail here you can read the FOSUserBundle documentation as reference.
 
-**Note:** Using the app/console commands of the FOSUserBundle is currently not supported.
+Original commands can be used, but require you also include the '--user-system' parameter,
+to indicate which user-system must be used.
+
+```bash
+php app/console fos:user:create --user-system=acme_user matthieu
+```
 
 **Note: Each user-system must have its own Form types to functional properly,
   you can not reuse form types for multiple user-systems.**

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/ActivateUserCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/ActivateUserCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\ActivateUserCommand as BaseActivateUserCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class ActivateUserCommand extends BaseActivateUserCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = $this->getDefinition();
+        $definition->addArgument(
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use')
+        );
+
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:activate</info> command activates a user (so they will be able to log in):
+
+  <info>php app/console fos:user:activate --user-system=acme_user matthieu</info>
+EOT
+            );
+    }
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/ChangePasswordCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/ChangePasswordCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\ChangePasswordCommand as BaseChangePasswordCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class ChangePasswordCommand extends BaseChangePasswordCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = $this->getDefinition();
+        $definition->addArgument(
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use')
+        );
+
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:change-password</info> command changes the password of a user:
+
+  <info>php app/console fos:user:change-password --user-system=acme_user matthieu</info>
+
+This interactive shell will first ask you for a password.
+
+You can alternatively specify the password as a second argument:
+
+  <info>php app/console fos:user:change-password --user-system=acme_user matthieu mypassword</info>
+
+EOT
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/CreateUserCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/CreateUserCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\CreateUserCommand as BaseCreateUserCommand;
+use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class CreateUserCommand extends BaseCreateUserCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = $this->getDefinition();
+        $definition->addArgument(
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use')
+        );
+
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:create</info> command creates a user:
+
+  <info>php app/console fos:user:create --user-system=acme_user matthieu</info>
+
+This interactive shell will ask you for an email and then a password.
+
+You can alternatively specify the email and password as the second and third arguments:
+
+  <info>php app/console fos:user:create --user-system=acme_user matthieu matthieu@example.com mypassword</info>
+
+You can create a super admin via the super-admin flag:
+
+  <info>php app/console fos:user:create admin --super-admin</info>
+
+You can create an inactive user (will not be able to log in):
+
+  <info>php app/console fos:user:create thibault --inactive</info>
+
+EOT
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/DeactivateUserCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/DeactivateUserCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\DeactivateUserCommand as BaseDeactivateUserCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class DeactivateUserCommand extends BaseDeactivateUserCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = $this->getDefinition();
+        $definition->addArgument(
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use')
+        );
+
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:deactivate</info> command deactivates a user (will not be able to log in)
+
+  <info>php app/console fos:user:deactivate --user-system=acme_user matthieu</info>
+EOT
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/DemoteUserCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/DemoteUserCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\DemoteUserCommand as BaseDemoteUserCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class DemoteUserCommand extends BaseDemoteUserCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = new InputDefinition();
+        $definition->setDefinition(array(
+            new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use'),
+            new InputArgument('role', InputArgument::OPTIONAL, 'The role'),
+            new InputOption('super', null, InputOption::VALUE_NONE, 'Instead specifying role, use this to quickly add the super administrator role'),
+        ));
+
+
+        $this->setDefinition($definition);
+
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:demote</info> command demotes a user by removing a role
+
+  <info>php app/console fos:user:demote --user-system=acme_user matthieu ROLE_CUSTOM</info>
+  <info>php app/console fos:user:demote --user-system=acme_user --super matthieu</info>
+EOT
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Command/PromoteUserCommand.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Command/PromoteUserCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Command;
+
+use FOS\UserBundle\Command\PromoteUserCommand as BasePromoteUserCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class PromoteUserCommand extends BasePromoteUserCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $definition = new InputDefinition();
+        $definition->setDefinition(array(
+            new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+            new InputArgument('user-system', InputArgument::REQUIRED, 'The user-system to use'),
+            new InputArgument('role', InputArgument::OPTIONAL, 'The role'),
+            new InputOption('super', null, InputOption::VALUE_NONE, 'Instead specifying role, use this to quickly add the super administrator role'),
+        ));
+
+
+        $this->setDefinition($definition);
+        $this
+            ->setHelp(<<<EOT
+The <info>fos:user:promote</info> command promotes a user by adding a role
+
+  <info>php app/console fos:user:promote --user-system=acme_user matthieu ROLE_CUSTOM</info>
+  <info>php app/console fos:user:promote --user-system=acme_user --super matthieu</info>
+EOT
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var UserDiscriminatorInterface $discriminator */
+        $discriminator = $this->getContainer()->get('rollerworks_multi_user.user_discriminator');
+        $discriminator->setCurrentUser($input->getArgument('user-system'));
+
+        parent::interact($input, $output);
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/Entity/Admin.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/Entity/Admin.php
@@ -26,4 +26,9 @@ class Admin extends BaseUser
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
+
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
+    }
 }

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/ActivateUserCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/ActivateUserCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\ActivateUserCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class ActivateUserCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDeactivateUser()
+    {
+        $command = new ActivateUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:activate');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $user = $acmeAdminUserManager->createUser();
+        $user->setEmail('test@example.com');
+        $user->setUsername('testUser');
+        $user->setPlainPassword('very-not-secure');
+        $user->setEnabled(false);
+
+        $acmeAdminUserManager->updateUser($user);
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+        $this->assertTrue($acmeAdminUserManager->findUserByUsername('testUser')->isEnabled());
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/ChangePasswordCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/ChangePasswordCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\ChangePasswordCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class ChangePasswordCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testChangePassword()
+    {
+        $command = new ChangePasswordCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:change-password');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $user = $acmeAdminUserManager->createUser();
+        $user->setEmail('test@example.com');
+        $user->setUsername('testUser');
+        $user->setPlainPassword('very-not-secure');
+        $user->setSalt('pepper');
+
+        $acmeAdminUserManager->updateUser($user);
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'password' => 'very-not-secure-or-something-like-that',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+        $this->assertEquals('9yAbiKi2nm0TBdTh4YY1QJSeZ0UAVppiz/UyxZRfsghWhvoR36k44KOBn9x3stCNSW0vvJyvq/IaVNvvx5P7Ug==', $acmeAdminUserManager->findUserByUsername('testUser')->getPassword());
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/CommandTestCase.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/CommandTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Tests\Functional\WebTestCaseFunctional;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+abstract class CommandTestCase extends WebTestCaseFunctional
+{
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    public function setUp()
+    {
+        $client = static::newClient(array('config' => 'admin.yml'));
+        $this->application = new Application($client->getKernel());
+
+        $this->deleteAllUsers('acme_admin');
+        $this->deleteAllUsers('acme_user');
+    }
+
+    protected function deleteAllUsers($userSys)
+    {
+        $container = $this->application->getKernel()->getContainer();
+        $userManager = $container->get($userSys . '.user_manager');
+
+        foreach ($userManager->findUsers() as $user) {
+            $userManager->deleteUser($user);
+        }
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\CreateUserCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class CreateUserCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCreateUser()
+    {
+        $command = new CreateUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:create');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $this->assertNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'email' => 'test@example.com',
+            'password' => 'very-not-secure',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'email' => 'test@example.com',
+            'password' => 'very-not-secure',
+            'user-system' => 'acme_user'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNotNull($acmeUserUserManager->findUserByUsername('testUser'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCreateUserMissingUserSystem()
+    {
+        $command = new CreateUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:create');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $this->setExpectedException('LogicException', 'Impossible to set the user discriminator, because "" is not present in the users list.');
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'email' => 'test@example.com',
+            'password' => 'very-not-secure'
+        ));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCreateUserInvalidUserSystem()
+    {
+        $command = new CreateUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:create');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $this->setExpectedException('LogicException', 'Impossible to set the user discriminator, because "acme_nothing" is not present in the users list.');
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'email' => 'test@example.com',
+            'password' => 'very-not-secure',
+            'user-system' => 'acme_nothing'
+        ));
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/DeactivateUserCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/DeactivateUserCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\DeactivateUserCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class DeactivateUserCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDeactivateUser()
+    {
+        $command = new DeactivateUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:deactivate');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $user = $acmeAdminUserManager->createUser();
+        $user->setEmail('test@example.com');
+        $user->setUsername('testUser');
+        $user->setPlainPassword('very-not-secure');
+        $user->setEnabled(true);
+
+        $acmeAdminUserManager->updateUser($user);
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+        $this->assertFalse($acmeAdminUserManager->findUserByUsername('testUser')->isEnabled());
+
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/DemoteUserCommandCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/DemoteUserCommandCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\DemoteUserCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class DemoteUserCommandCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDemote()
+    {
+        $command = new DemoteUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:demote');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $user = $acmeAdminUserManager->createUser();
+        $user->setEmail('test@example.com');
+        $user->setUsername('testUser');
+        $user->setPlainPassword('very-not-secure');
+        $user->setEnabled(false);
+        $user->addRole('ROLE_INVOICE_CREATE');
+
+        $acmeAdminUserManager->updateUser($user);
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+        $this->assertContains('ROLE_INVOICE_CREATE', $acmeAdminUserManager->findUserByUsername('testUser')->getRoles());
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'role' => 'ROLE_INVOICE_CREATE',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $this->assertNotContains('ROLE_INVOICE_CREATE', $acmeAdminUserManager->findUserByUsername('testUser')->getRoles());
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/PromoteUserCommandCommandTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Command/PromoteUserCommandCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Command;
+
+use Rollerworks\Bundle\MultiUserBundle\Command\PromoteUserCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class PromoteUserCommandCommandTest extends CommandTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testDemote()
+    {
+        $command = new PromoteUserCommand();
+        $this->application->add($command);
+
+        $command = $this->application->find('fos:user:promote');
+        $commandTester = new CommandTester($command);
+
+        $container = $this->application->getKernel()->getContainer();
+
+        $acmeAdminUserManager = $container->get('acme_admin.user_manager');
+        $acmeUserUserManager = $container->get('acme_user.user_manager');
+
+        $user = $acmeAdminUserManager->createUser();
+        $user->setEmail('test@example.com');
+        $user->setUsername('testUser');
+        $user->setPlainPassword('very-not-secure');
+        $user->setEnabled(false);
+
+        $acmeAdminUserManager->updateUser($user);
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+        $this->assertNotContains('ROLE_INVOICE_CREATE', $acmeAdminUserManager->findUserByUsername('testUser')->getRoles());
+
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'testUser',
+            'role' => 'ROLE_INVOICE_CREATE',
+            'user-system' => 'acme_admin'
+        ));
+
+        $this->assertNotNull($acmeAdminUserManager->findUserByUsername('testUser'));
+        $this->assertNull($acmeUserUserManager->findUserByUsername('testUser'));
+
+        $this->assertContains('ROLE_INVOICE_CREATE', $acmeAdminUserManager->findUserByUsername('testUser')->getRoles());
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/doctrine.yml
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/doctrine.yml
@@ -1,7 +1,7 @@
 doctrine:
     dbal:
         driver: pdo_sqlite
-        path: "%kernel.cache_dir%/user_test.db"
+        path: "%kernel.cache_dir%/../user_test.db"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | no |
| Deprecations? | no |
| Tests Pass? | not yet |
| Fixed Tickets | GH-2 |
| License | MIT |

This adds support for working with the original FOSUserBundle commands.
This overwrites the existing commands and adds the 'user-system' parameter as requirement.
