### PR TITLE
fix the e-mail confirmation listener

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
@@ -506,6 +506,7 @@ class UserServicesFactory
         }
 
         $container->setParameter($this->servicePrefix . '.registration.confirmation.from_email', array($fromEmail['address'] => $fromEmail['sender_name']));
+        $user->addMethodCall('setConfig', array('registering.confirmation.enabled', isset($config['confirmation']) ? $config['confirmation']['enabled'] : false));
 
         $this->remapParametersNamespaces($config, $container, array(
             'confirmation' => $this->servicePrefix . '.registration.confirmation.%s',

--- a/src/Rollerworks/Bundle/MultiUserBundle/EventListener/EmailConfirmationListener.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/EventListener/EmailConfirmationListener.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\EventListener;
+
+use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Event\FormEvent;
+use FOS\UserBundle\Mailer\MailerInterface;
+use FOS\UserBundle\Util\TokenGeneratorInterface;
+use Rollerworks\Bundle\MultiUserBundle\Model\UserDiscriminatorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class EmailConfirmationListener implements EventSubscriberInterface
+{
+    private $mailer;
+    private $tokenGenerator;
+    private $router;
+    private $session;
+
+    /**
+     * @var UserDiscriminatorInterface
+     */
+    private $userDiscriminator;
+
+    public function __construct(MailerInterface $mailer, TokenGeneratorInterface $tokenGenerator, UrlGeneratorInterface $router, SessionInterface $session, UserDiscriminatorInterface $userDiscriminator)
+    {
+        $this->mailer = $mailer;
+        $this->tokenGenerator = $tokenGenerator;
+        $this->router = $router;
+        $this->session = $session;
+        $this->userDiscriminator = $userDiscriminator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::REGISTRATION_SUCCESS => 'onRegistrationSuccess',
+        );
+    }
+
+    public function onRegistrationSuccess(FormEvent $event)
+    {
+        if (!$this->userDiscriminator->getCurrentUserConfig()->getConfig('registering.confirmation.enabled', false)) {
+            return ;
+        }
+
+        /** @var $user \FOS\UserBundle\Model\UserInterface */
+        $user = $event->getForm()->getData();
+
+        $user->setEnabled(false);
+        if (null === $user->getConfirmationToken()) {
+            $user->setConfirmationToken($this->tokenGenerator->generateToken());
+        }
+
+        $this->mailer->sendConfirmationEmailMessage($user);
+        $this->session->set('fos_user_send_confirmation_email/email', $user->getEmail());
+
+        $url = $this->router->generate($this->userDiscriminator->getCurrentUserConfig()->getRoutePrefix() . '_registration_check_email');
+        $event->setResponse(new RedirectResponse($url));
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Mailer/DelegatingMailer.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Mailer/DelegatingMailer.php
@@ -29,7 +29,7 @@ class DelegatingMailer implements MailerInterface
 
     public function sendConfirmationEmailMessage(UserInterface $user)
     {
-        $this->container->get($this->userDiscriminator->getCurrentUserConfig()->getServicePrefix() . '.mailer')->sendConfirmation($user);
+        $this->container->get($this->userDiscriminator->getCurrentUserConfig()->getServicePrefix() . '.mailer')->sendConfirmationEmailMessage($user);
     }
 
     public function sendResettingEmailMessage(UserInterface $user)

--- a/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Resources/config/container/listeners.xml
@@ -16,6 +16,15 @@
             <argument type="service" id="rollerworks_multi_user.user_discriminator" />
         </service>
 
+        <service id="rollerworks_multi_user.listener.email_confirmation" class="Rollerworks\Bundle\MultiUserBundle\EventListener\EmailConfirmationListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="rollerworks_multi_user.mailer.delegating" />
+            <argument type="service" id="fos_user.util.token_generator" />
+            <argument type="service" id="router" />
+            <argument type="service" id="session" />
+            <argument type="service" id="rollerworks_multi_user.user_discriminator" />
+        </service>
+
         <service id="rollerworks_multi_user.listener.resetting" class="Rollerworks\Bundle\MultiUserBundle\EventListener\ResettingListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="router" />

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/UserBundle/DependencyInjection/AcmeUserExtension.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/UserBundle/DependencyInjection/AcmeUserExtension.php
@@ -54,6 +54,9 @@ class AcmeUserExtension extends Extension
                 ),
 
                 'registration' => array(
+                    'confirmation' => array(
+                        'enabled' => true,
+                    ),
                     'template' => array(
                         'register' => 'AcmeUserBundle:Registration:register.html.twig',
                         'check_email' => 'AcmeUserBundle:Registration:checkEmail.html.twig',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets | GH-21 GH-22 |
| License | MIT |
| Doc PR |  |

fixes the e-mail confirmation listener. This only will only sent an confirmation e-mail, when the user-system registering.confirmation.enabled is true
