### PR TITLE
Allow forms to work directly, and no longer require explicit overwrite

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
@@ -242,6 +242,24 @@ class UserServicesFactory
         ));
     }
 
+    protected function convertFormType(ContainerBuilder $container, $type, array $config, $modelRef = null)
+    {
+        if ('fos_user_' . $type === $config['type'] || 'FOS\\UserBundle\\Form\\Type\\' === substr($config['class'], 0, 25) || 'fos_user_' . $type . '_form' === $config['name']) {
+            $config['type'] = sprintf('%s_%s',  $this->servicePrefix, $type);
+            $config['class'] = 'Rollerworks\\Bundle\\MultiUserBundle\Form\\Type\\' . join('', array_slice(explode('\\', $config['class']), -1));
+            $config['name'] = sprintf('%s_%s_form',  $this->servicePrefix, $type);
+
+            $container->setDefinition(sprintf('%s.%s.form.type', $this->servicePrefix, $type), new Definition($config['class']))
+                ->setTags(array('form.type' => array(array('alias' => $config['type']))))
+                ->addArgument(sprintf('%%%s.model.%s.class%%', $this->servicePrefix, $modelRef))
+                ->addArgument($config['type']);
+
+            $config['class'] = null;
+        }
+
+        return $config;
+    }
+
     /**
      * @param string     $section
      * @param array      $config
@@ -485,6 +503,7 @@ class UserServicesFactory
 
     private function loadProfile(array $config, ContainerBuilder $container, Definition $user)
     {
+        $config['form'] = $this->convertFormType($container, 'profile', $config['form'], 'user');
         $this->createFormService($container, 'profile', $config, $user, 'user');
         $this->setTemplates('profile', $config, $user);
 
@@ -496,6 +515,7 @@ class UserServicesFactory
 
     private function loadRegistration(array $config, ContainerBuilder $container, Definition $user, array $fromEmail)
     {
+        $config['form'] = $this->convertFormType($container, 'registration', $config['form'], 'user');
         $this->createFormService($container, 'registration', $config, $user, 'user');
         $this->setTemplates('registration', $config, $user);
 
@@ -525,6 +545,7 @@ class UserServicesFactory
 
     private function loadChangePassword(array $config, ContainerBuilder $container, Definition $user)
     {
+        $config['form'] = $this->convertFormType($container, 'change_password', $config['form'], 'user');
         $this->createFormService($container, 'change_password', $config, $user, 'user');
         $this->setTemplates('change_password', $config, $user);
 
@@ -536,6 +557,7 @@ class UserServicesFactory
 
     private function loadResetting(array $config, ContainerBuilder $container, Definition $user, array $fromEmail)
     {
+        $config['form'] = $this->convertFormType($container, 'resetting', $config['form'], 'user');
         $this->createFormService($container, 'resetting', $config, $user, 'user');
         $this->setTemplates('resetting', $config, $user);
 
@@ -572,6 +594,7 @@ class UserServicesFactory
             ->setPublic(false);
         }
 
+        $config['form'] = $this->convertFormType($container, 'group', $config['form'], 'group');
         $this->createFormService($container, 'group', $config, $user, 'group');
 
         if (sprintf('%s.group_manager', $this->servicePrefix) !== $config['group_manager']) {

--- a/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ChangePasswordFormType.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ChangePasswordFormType.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+
+class ChangePasswordFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @param string $class    The User class name
+     * @param string $typeName The FormType name
+     */
+    public function __construct($class, $typeName)
+    {
+        $this->class = $class;
+        $this->typeName = $typeName;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $constraint = new UserPassword();
+
+        $builder
+            ->add('current_password', 'password', array(
+                'label' => 'form.current_password',
+                'translation_domain' => 'FOSUserBundle',
+                'mapped' => false,
+                'constraints' => $constraint,
+            ))
+            ->add('plainPassword', 'repeated', array(
+                'type' => 'password',
+                'options' => array('translation_domain' => 'FOSUserBundle'),
+                'first_options' => array('label' => 'form.new_password'),
+                'second_options' => array('label' => 'form.new_password_confirmation'),
+                'invalid_message' => 'fos_user.password.mismatch',
+            ));
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'change_password',
+        ));
+    }
+
+    public function getName()
+    {
+        return $this->typeName;
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/GroupFormType.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/GroupFormType.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class GroupFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @param string $class    The User class name
+     * @param string $typeName The FormType name
+     */
+    public function __construct($class, $typeName)
+    {
+        $this->class = $class;
+        $this->typeName = $typeName;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('name', null, array('label' => 'form.group_name', 'translation_domain' => 'FOSUserBundle'));
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'group',
+        ));
+    }
+
+    public function getName()
+    {
+        return $this->typeName;
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ProfileFormType.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ProfileFormType.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+
+class ProfileFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @param string $class    The User class name
+     * @param string $typeName The FormType name
+     */
+    public function __construct($class, $typeName)
+    {
+        $this->class = $class;
+        $this->typeName = $typeName;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $constraint = new UserPassword();
+        $this->buildUserForm($builder, $options);
+
+        $builder->add('current_password', 'password', array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => $constraint,
+        ));
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'profile',
+        ));
+    }
+
+    public function getName()
+    {
+        return $this->typeName;
+    }
+
+    /**
+     * Builds the embedded form representing the user.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    protected function buildUserForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+        ;
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/RegistrationFormType.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/RegistrationFormType.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class RegistrationFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @param string $class    The User class name
+     * @param string $typeName The FormType name
+     */
+    public function __construct($class, $typeName)
+    {
+        $this->class = $class;
+        $this->typeName = $typeName;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('email', 'email', array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('plainPassword', 'repeated', array(
+                'type' => 'password',
+                'options' => array('translation_domain' => 'FOSUserBundle'),
+                'first_options' => array('label' => 'form.password'),
+                'second_options' => array('label' => 'form.password_confirmation'),
+                'invalid_message' => 'fos_user.password.mismatch',
+            ))
+        ;
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'registration',
+        ));
+    }
+
+    public function getName()
+    {
+        return $this->typeName;
+    }
+}

--- a/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ResettingFormType.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Form/Type/ResettingFormType.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class ResettingFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @param string $class    The User class name
+     * @param string $typeName The FormType name
+     */
+    public function __construct($class, $typeName)
+    {
+        $this->class = $class;
+        $this->typeName = $typeName;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('plainPassword', 'repeated', array(
+            'type' => 'password',
+            'options' => array('translation_domain' => 'FOSUserBundle'),
+            'first_options' => array('label' => 'form.new_password'),
+            'second_options' => array('label' => 'form.new_password_confirmation'),
+            'invalid_message' => 'fos_user.password.mismatch',
+        ));
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'intention'  => 'resetting',
+        ));
+    }
+
+    public function getName()
+    {
+        return $this->typeName;
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
@@ -359,9 +359,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\ProfileFormType',
-            'type' => 'fos_user_profile',
-            'name' => 'fos_user_profile_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\ProfileFormType',
+            'type' => 'acme_user_profile',
+            'name' => 'acme_user_profile_form',
             'validation_groups' => array('Profile', 'Default'),
         );
 
@@ -479,9 +479,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\RegistrationFormType',
-            'type' => 'fos_user_registration',
-            'name' => 'fos_user_registration_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\RegistrationFormType',
+            'type' => 'acme_user_registration',
+            'name' => 'acme_user_registration_form',
             'validation_groups' => array('Registration', 'Default'),
         );
 
@@ -540,9 +540,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\RegistrationFormType',
-            'type' => 'fos_user_registration',
-            'name' => 'fos_user_registration_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\RegistrationFormType',
+            'type' => 'acme_user_registration',
+            'name' => 'acme_user_registration_form',
             'validation_groups' => array('Registration', 'Default'),
         );
 
@@ -614,9 +614,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\ResettingFormType',
-            'type' => 'fos_user_resetting',
-            'name' => 'fos_user_resetting_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\ResettingFormType',
+            'type' => 'acme_user_resetting',
+            'name' => 'acme_user_resetting_form',
             'validation_groups' => array('Resetting', 'Default'),
         );
 
@@ -673,9 +673,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\ChangePasswordFormType',
-            'type' => 'fos_user_change_password',
-            'name' => 'fos_user_change_password_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\ChangePasswordFormType',
+            'type' => 'acme_user_change_password',
+            'name' => 'acme_user_change_password_form',
             'validation_groups' => array('ChangePassword', 'Default'),
         );
 
@@ -736,9 +736,9 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
 
         $expected = array(
-            'class' => 'FOS\UserBundle\Form\Type\GroupFormType',
-            'type' => 'fos_user_change_password',
-            'name' => 'fos_user_change_password_form',
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Form\Type\GroupFormType',
+            'type' => 'acme_user_change_password',
+            'name' => 'acme_user_change_password_form',
             'validation_groups' => array('Registration', 'Default'),
         );
 

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/RegistrationControllerTest.php
@@ -32,10 +32,10 @@ class RegistrationControllerTest extends WebTestCaseFunctional
         $this->assertEquals($crawler->filter('form')->count(), 1);
 
         $form = $crawler->selectButton('Register')->form();
-        $form['fos_user_registration_form[username]'] = 'dummy-example';
-        $form['fos_user_registration_form[email]'] = 'dummy-example@example.com';
-        $form['fos_user_registration_form[plainPassword][first]'] = 'mySecret0Password';
-        $form['fos_user_registration_form[plainPassword][second]'] = 'mySecret0Password';
+        $form['acme_admin_registration_form[username]'] = 'dummy-example';
+        $form['acme_admin_registration_form[email]'] = 'dummy-example@example.com';
+        $form['acme_admin_registration_form[plainPassword][first]'] = 'mySecret0Password';
+        $form['acme_admin_registration_form[plainPassword][second]'] = 'mySecret0Password';
 
         $client->submit($form);
         $this->assertTrue($client->getResponse()->isRedirect('/admin/register/confirmed'));
@@ -139,10 +139,10 @@ class RegistrationControllerTest extends WebTestCaseFunctional
         $this->assertEquals($crawler->filter('form')->count(), 1);
 
         $form = $crawler->selectButton('Register')->form();
-        $form['fos_user_registration_form[username]'] = 'dummy-example';
-        $form['fos_user_registration_form[email]'] = 'dummy-example2@example.com';
-        $form['fos_user_registration_form[plainPassword][first]'] = 'mySecret0Password';
-        $form['fos_user_registration_form[plainPassword][second]'] = 'mySecret0Password';
+        $form['acme_admin_registration_form[username]'] = 'dummy-example';
+        $form['acme_admin_registration_form[email]'] = 'dummy-example2@example.com';
+        $form['acme_admin_registration_form[plainPassword][first]'] = 'mySecret0Password';
+        $form['acme_admin_registration_form[plainPassword][second]'] = 'mySecret0Password';
 
         $client->submit($form);
         $this->assertTrue($client->getResponse()->isRedirect('/admin/register/confirmed'));

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -72,8 +72,8 @@ class ResettingControllerTest extends WebTestCaseFunctional
         $this->assertEquals($crawler->filter('form')->count(), 1);
 
         $form = $crawler->selectButton('Change password')->form();
-        $form['fos_user_resetting_form[plainPassword][first]'] = 'mySecret0Password';
-        $form['fos_user_resetting_form[plainPassword][second]'] = 'mySecret0Password';
+        $form['acme_admin_resetting_form[plainPassword][first]'] = 'mySecret0Password';
+        $form['acme_admin_resetting_form[plainPassword][second]'] = 'mySecret0Password';
 
         $client->submit($form);
         $this->assertTrue($client->getResponse()->isRedirect('/admin/profile/'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | yes |
| Deprecations? | no |
| Tests Pass? | yes |
| Fixed Tickets |  |

This change allows a user-system to reuse the default form types.

When a form-type begins with 'fos_user' prefix the UserServicesFactory will register the form-type with the service-prefix (and it own name), using the RollerworksMultiUserBundle form types which allow a customizable name.

**In short:** the user-bundle is no longer required to always define its own form classes in order to work properly. Which will make bootstrapping a new user-bundle a little easier.
And of course you can still use your own form-types as before.

One important BC breaking change is that each form-name is prefixed with the service prefix and not the fos_user prefix (as before), even when your only using one user-system.
This is not a big problem, but may break your functional tests. :boom:
