### PR TITLE
Fixes custom user-configuration building

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/browser-kit":         "~2.2",
         "symfony/css-selector":        "~2.2",
         "symfony/process":             "~2.2",
-        "symfony/expression-language": "~2.4"
+        "symfony/expression-language": "~2.4",
+        "matthiasnoback/symfony-config-test": "0.*,>=0.1.1"
     },
     "conflict": {
         "pugx/multi-user-bundle": "*"

--- a/docs/index.md
+++ b/docs/index.md
@@ -357,8 +357,33 @@ class Configuration implements ConfigurationInterface
 Now you can now easily configure the user-bundle in your `app/config/config.yml`
 config using the `acme_user` configuration-tree.
 
-> You can limit what is configurable by passing an array as second parameter to `UserConfiguration::addUserConfig()`
-> Available values are: 'profile', 'change_password', 'registration', 'resetting', 'group'.
+You can limit what is configurable by passing a bitmask as second parameter to `UserConfiguration::addUserConfig()`
+
+Available constants of the `Rollerworks\Bundle\MultiUserBundle\DependencyInjection\Configuration` class are:
+
+* CONFIG_SECTION_PROFILE
+* CONFIG_SECTION_CHANGE_PASSWORD
+* CONFIG_SECTION_REGISTRATION
+* CONFIG_SECTION_RESETTING
+* CONFIG_SECTION_GROUP
+* CONFIG_SECTION_SECURITY
+
+* CONFIG_DB_DRIVER
+* CONFIG_REQUEST_MATCHER
+* CONFIG_USER_CLASS
+
+* CONFIG_ALL
+
+To enable everything (which is the default) use `Configuration::CONFIG_ALL`.
+
+To remove what is configurable, use the `^` operator, `Configuration::CONFIG_ALL ^ Configuration::CONFIG_SECTION_GROUP`
+will allow everything but the Group configuration.
+
+The other way around is to define explicitly with `|`.
+
+`Configuration::CONFIG_SECTION_CHANGE_PASSWORD | Configuration::CONFIG_SECTION_PROFILE`
+
+Will only enable the change-password and profile configuration, and nothing more.
 
 **Note:** The `UserServicesFactory::create()` ignores any unknown configuration-keys that are passed to it, so you don't
 have to worry about passing to much.

--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Configuration.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Configuration.php
@@ -20,6 +20,21 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    const CONFIG_SECTION_PROFILE = 1;
+    const CONFIG_SECTION_CHANGE_PASSWORD = 2;
+    const CONFIG_SECTION_REGISTRATION = 4;
+    const CONFIG_SECTION_RESETTING = 8;
+    const CONFIG_SECTION_GROUP = 16;
+    const CONFIG_SECTION_SECURITY = 32;
+
+    const CONFIG_DB_DRIVER = 64;
+    const CONFIG_REQUEST_MATCHER = 128;
+    const CONFIG_USER_CLASS = 256;
+
+    const CONFIG_ALL = 511;
+
+    private static $supportedDrivers = array('orm', 'mongodb', 'couchdb', 'custom');
+
     /**
      * {@inheritDoc}
      */
@@ -62,7 +77,6 @@ class Configuration implements ConfigurationInterface
 
     /**
      * @param ArrayNodeDefinition $rootNode
-     * @param array               $enableServices array of configurations to enable: 'profile', 'change_password', 'registration', 'resetting', 'group'
      *
      * @return ArrayNodeDefinition
      *
@@ -70,17 +84,15 @@ class Configuration implements ConfigurationInterface
      *
      * @internal
      */
-    final public function addUserConfig(ArrayNodeDefinition $rootNode, array $enableServices = array('profile', 'change_password', 'registration', 'resetting', 'group'))
+    final public function addUserSysConfig(ArrayNodeDefinition $rootNode)
     {
-        $supportedDrivers = array('orm', 'mongodb', 'couchdb', 'custom');
-
         $rootNode
             ->children()
                 ->scalarNode('db_driver')
                     ->defaultValue('orm')
                     ->validate()
-                        ->ifNotInArray($supportedDrivers)
-                        ->thenInvalid('The driver %s is not supported. Please choose one of: ' . implode(',', $supportedDrivers))
+                        ->ifNotInArray(self::$supportedDrivers)
+                        ->thenInvalid('The driver %s is not supported. Please choose one of: ' . implode(',', self::$supportedDrivers))
                     ->end()
                 ->end()
                 ->booleanNode('use_listener')->defaultTrue()->end()
@@ -116,214 +128,478 @@ class Configuration implements ConfigurationInterface
         $this->addServiceSection($rootNode);
         $this->addTemplateSection($rootNode);
 
-        $availableSections = array('profile', 'change_password', 'registration', 'resetting', 'group');
-        $camelize = function ($match) {
-            return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
-        };
-
-        foreach ($enableServices as $serviceName) {
-            if (!in_array($serviceName, $availableSections)) {
-                throw new \InvalidArgumentException(sprintf('Unable to add unknown configuration-section "%s".', $serviceName));
-            }
-
-            $methodName = 'add' . preg_replace_callback('/(^|_|\.)+(.)/', $camelize, $serviceName) . 'Section';
-            call_user_func(array($this, $methodName), $rootNode);
-        }
+        $this->addProfileSection($rootNode);
+        $this->addChangePasswordSection($rootNode);
+        $this->addRegistrationSection($rootNode);
+        $this->addResettingSection($rootNode);
+        $this->addGroupSection($rootNode);
 
         return $rootNode;
     }
 
-    final public function addSecuritySection(ArrayNodeDefinition $node)
+    /**
+     * Adds the user-configuration to the $rootNode.
+     *
+     * To specify which configurations are added use a Bitmask value.
+     *
+     * For example;
+     *
+     * Configuration::CONFIG_ALL ^ Configuration::CONFIG_SECTION_PROFILE
+     * Will enable everything except profile configuration.
+     *
+     * Configuration::CONFIG_SECTION_PROFILE | self::CONFIG_SECTION_CHANGE_PASSWORD
+     * Will enable only the profile and change-password.
+     *
+     * Note. firewall_name, model_manager_name, use_username_form_type, from_email are always configurable.
+     * When calling this method.
+     *
+     * @param ArrayNodeDefinition $rootNode
+     * @param array|integer       $enableServices Bitmask of enabled configurations or array of enabled-services (compatibility only)
+     *                                            Accepted array values: 'profile', 'change_password', 'registration', 'resetting', 'group'
+     *
+     * @return ArrayNodeDefinition
+     *
+     * @throws \InvalidArgumentException on unknown section
+     *
+     * @internal
+     */
+    final public function addUserConfig(ArrayNodeDefinition $rootNode, $enableServices = self::CONFIG_ALL)
     {
-        $node
+        if (is_array($enableServices)) {
+            $enableServices = $this->convertArrayToBitmask($enableServices);
+        }
+
+        $supportedDrivers = self::$supportedDrivers;
+
+        $rootNode
             ->children()
-                ->arrayNode('security')
-                    ->addDefaultsIfNotSet()
+                ->scalarNode('firewall_name')->end()
+                ->scalarNode('model_manager_name')->end()
+                ->booleanNode('use_username_form_type')->end()
+                ->arrayNode('from_email')
                     ->children()
-                        ->arrayNode('login')
-                            ->children()
-                                ->scalarNode('template')->defaultValue('RollerworksMultiUserBundle:UserBundle/Security:login.html.twig')->end()
-                            ->end()
-                        ->end()
+                        ->scalarNode('address')->end()
+                        ->scalarNode('sender_name')->end()
                     ->end()
                 ->end()
             ->end()
         ;
+
+        if ($enableServices & self::CONFIG_DB_DRIVER) {
+            $rootNode
+                ->children()
+                    ->scalarNode('db_driver')
+                        ->validate()
+                            ->ifTrue(function ($v) use ($supportedDrivers) { return $v !== null && !in_array($v, $supportedDrivers); })
+                            ->thenInvalid('The driver %s is not supported. Please choose one of: ' . implode(',', $supportedDrivers))
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
+
+        if ($enableServices & self::CONFIG_REQUEST_MATCHER) {
+            $rootNode
+                ->children()
+                    ->scalarNode('path')->end()
+                    ->scalarNode('host')->end()
+                    ->scalarNode('request_matcher')->end()
+                ->end()
+            ;
+        }
+
+        if ($enableServices & self::CONFIG_USER_CLASS) {
+            $rootNode
+                ->children()
+                    ->scalarNode('user_class')->end()
+                ->end()
+            ;
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_PROFILE) {
+            $this->addProfileSection($rootNode, false);
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_CHANGE_PASSWORD) {
+            $this->addChangePasswordSection($rootNode, false);
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_REGISTRATION) {
+            $this->addRegistrationSection($rootNode, false);
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_RESETTING) {
+            $this->addResettingSection($rootNode, false);
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_GROUP) {
+            $this->addGroupSection($rootNode, false);
+        }
+
+        if ($enableServices & self::CONFIG_SECTION_SECURITY) {
+            $this->addSecuritySection($rootNode, false);
+        }
+
+        $this->addTemplateSection($rootNode, false);
+
+        return $rootNode;
+    }
+
+    final public function addSecuritySection(ArrayNodeDefinition $node, $defaults = true)
+    {
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('security')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->arrayNode('login')
+                                ->children()
+                                    ->scalarNode('template')->defaultValue('RollerworksMultiUserBundle:UserBundle/Security:login.html.twig')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('security')
+                        ->children()
+                            ->arrayNode('login')
+                                ->children()
+                                    ->scalarNode('template')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
     }
 
     // Everything below this is copied from the FOSUserBundle, and is considered @internal
     // Its only marked public for call_user_func() in addUserConfig()
 
-    final public function addProfileSection(ArrayNodeDefinition $node)
+    final public function addProfileSection(ArrayNodeDefinition $node, $defaults = true)
     {
-        $node
-            ->children()
-                ->arrayNode('profile')
-                    ->canBeUnset()
-                    ->children()
-                        ->arrayNode('form')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('type')->defaultValue('fos_user_profile')->end()
-                                ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ProfileFormType')->end()
-                                ->scalarNode('name')->defaultValue('fos_user_profile_form')->end()
-                                ->arrayNode('validation_groups')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array('Profile', 'Default'))
-                                ->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('template')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('edit')->defaultValue('RollerworksMultiUserBundle:UserBundle/Profile:edit.html.twig')->end()
-                                ->scalarNode('show')->defaultValue('RollerworksMultiUserBundle:UserBundle/Profile:show.html.twig')->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
-        ;
-    }
-
-    final public function addRegistrationSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('registration')
-                    ->canBeUnset()
-                    ->children()
-                        ->arrayNode('confirmation')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->booleanNode('enabled')->defaultFalse()->end()
-                                ->arrayNode('template')
-                                    ->addDefaultsIfNotSet()
-                                    ->children()
-                                        ->scalarNode('email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:email.txt.twig')->end()
-                                        ->scalarNode('confirmed')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:confirmed.html.twig')->end()
-                                    ->end()
-                                ->end()
-                                ->arrayNode('from_email')
-                                    ->canBeUnset()
-                                    ->children()
-                                        ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
-                                        ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('profile')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('form')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('type')->defaultValue('fos_user_profile')->end()
+                                    ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ProfileFormType')->end()
+                                    ->scalarNode('name')->defaultValue('fos_user_profile_form')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                        ->defaultValue(array('Profile', 'Default'))
                                     ->end()
                                 ->end()
                             ->end()
-                        ->end()
-                        ->arrayNode('form')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('type')->defaultValue('fos_user_registration')->end()
-                                ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\RegistrationFormType')->end()
-                                ->scalarNode('name')->defaultValue('fos_user_registration_form')->end()
-                                ->arrayNode('validation_groups')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array('Registration', 'Default'))
+                            ->arrayNode('template')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('edit')->defaultValue('RollerworksMultiUserBundle:UserBundle/Profile:edit.html.twig')->end()
+                                    ->scalarNode('show')->defaultValue('RollerworksMultiUserBundle:UserBundle/Profile:show.html.twig')->end()
                                 ->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('template')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('register')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:register.html.twig')->end()
-                                ->scalarNode('check_email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:checkEmail.html.twig')->end()
                             ->end()
                         ->end()
                     ->end()
                 ->end()
-            ->end()
-        ;
-    }
-
-    final public function addResettingSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('resetting')
-                    ->canBeUnset()
-                    ->children()
-                        ->integerNode('token_ttl')->defaultValue(86400)->end()
-                        ->arrayNode('email')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->arrayNode('from_email')
-                                    ->canBeUnset()
-                                    ->children()
-                                        ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
-                                        ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('profile')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('form')
+                                ->children()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('class')->end()
+                                    ->scalarNode('name')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
                                     ->end()
                                 ->end()
                             ->end()
-                        ->end()
-                        ->arrayNode('form')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('template')->defaultNull()->end()
-                                ->scalarNode('type')->defaultValue('fos_user_resetting')->end()
-                                ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ResettingFormType')->end()
-                                ->scalarNode('name')->defaultValue('fos_user_resetting_form')->end()
-                                ->arrayNode('validation_groups')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array('ResetPassword', 'Default'))
+                            ->arrayNode('template')
+                                ->children()
+                                    ->scalarNode('edit')->end()
+                                    ->scalarNode('show')->end()
                                 ->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('template')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('check_email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:checkEmail.html.twig')->end()
-                                ->scalarNode('email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:email.txt.twig')->end()
-                                ->scalarNode('password_already_requested')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:passwordAlreadyRequested.html.twig')->end()
-                                ->scalarNode('request')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:request.html.twig')->end()
-                                ->scalarNode('reset')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:reset.html.twig')->end()
-                            ->end()
-                        ->end()
-
-                    ->end()
-                ->end()
-            ->end()
-        ;
-    }
-
-    final public function addChangePasswordSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('change_password')
-                    ->canBeUnset()
-                    ->children()
-                        ->arrayNode('form')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('type')->defaultValue('fos_user_change_password')->end()
-                                ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ChangePasswordFormType')->end()
-                                ->scalarNode('name')->defaultValue('fos_user_change_password_form')->end()
-                                ->arrayNode('validation_groups')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array('ChangePassword', 'Default'))
-                                ->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('template')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('change_password')->defaultValue('RollerworksMultiUserBundle:UserBundle/ChangePassword:changePassword.html.twig')->end()
                             ->end()
                         ->end()
                     ->end()
                 ->end()
-            ->end()
-        ;
+            ;
+        }
     }
 
-    final public function addServiceSection(ArrayNodeDefinition $node)
+    final public function addRegistrationSection(ArrayNodeDefinition $node, $defaults = true)
     {
-        $node
-            ->children()
-                ->arrayNode('service')
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('registration')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('confirmation')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->booleanNode('enabled')->defaultFalse()->end()
+                                    ->arrayNode('template')
+                                        ->addDefaultsIfNotSet()
+                                        ->children()
+                                            ->scalarNode('email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:email.txt.twig')->end()
+                                            ->scalarNode('confirmed')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:confirmed.html.twig')->end()
+                                        ->end()
+                                    ->end()
+                                    ->arrayNode('from_email')
+                                        ->canBeUnset()
+                                        ->children()
+                                            ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
+                                            ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('form')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('type')->defaultValue('fos_user_registration')->end()
+                                    ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\RegistrationFormType')->end()
+                                    ->scalarNode('name')->defaultValue('fos_user_registration_form')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                        ->defaultValue(array('Registration', 'Default'))
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('register')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:register.html.twig')->end()
+                                    ->scalarNode('check_email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Registration:checkEmail.html.twig')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('registration')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('confirmation')
+                                ->children()
+                                    ->booleanNode('enabled')->end()
+                                    ->arrayNode('template')
+                                        ->children()
+                                            ->scalarNode('email')->end()
+                                            ->scalarNode('confirmed')->end()
+                                        ->end()
+                                    ->end()
+                                    ->arrayNode('from_email')
+                                        ->canBeUnset()
+                                        ->children()
+                                            ->scalarNode('address')->end()
+                                            ->scalarNode('sender_name')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('form')
+                                ->children()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('class')->end()
+                                    ->scalarNode('name')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->children()
+                                    ->scalarNode('register')->end()
+                                    ->scalarNode('check_email')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
+    }
+
+    final public function addResettingSection(ArrayNodeDefinition $node, $defaults = true)
+    {
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('resetting')
+                        ->canBeUnset()
+                        ->children()
+                            ->integerNode('token_ttl')->defaultValue(86400)->end()
+                            ->arrayNode('email')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->arrayNode('from_email')
+                                        ->canBeUnset()
+                                        ->children()
+                                            ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
+                                            ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('form')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('template')->defaultNull()->end()
+                                    ->scalarNode('type')->defaultValue('fos_user_resetting')->end()
+                                    ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ResettingFormType')->end()
+                                    ->scalarNode('name')->defaultValue('fos_user_resetting_form')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                        ->defaultValue(array('ResetPassword', 'Default'))
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('check_email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:checkEmail.html.twig')->end()
+                                    ->scalarNode('email')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:email.txt.twig')->end()
+                                    ->scalarNode('password_already_requested')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:passwordAlreadyRequested.html.twig')->end()
+                                    ->scalarNode('request')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:request.html.twig')->end()
+                                    ->scalarNode('reset')->defaultValue('RollerworksMultiUserBundle:UserBundle/Resetting:reset.html.twig')->end()
+                                ->end()
+                            ->end()
+
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('resetting')
+                        ->canBeUnset()
+                        ->children()
+                            ->integerNode('token_ttl')->end()
+                            ->arrayNode('email')
+                                ->children()
+                                    ->arrayNode('from_email')
+                                        ->canBeUnset()
+                                        ->children()
+                                            ->scalarNode('address')->end()
+                                            ->scalarNode('sender_name')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('form')
+                                ->children()
+                                    ->scalarNode('template')->end()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('class')->end()
+                                    ->scalarNode('name')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->children()
+                                    ->scalarNode('check_email')->end()
+                                    ->scalarNode('email')->end()
+                                    ->scalarNode('password_already_requested')->end()
+                                    ->scalarNode('request')->end()
+                                    ->scalarNode('reset')->end()
+                                ->end()
+                            ->end()
+
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
+    }
+
+    final public function addChangePasswordSection(ArrayNodeDefinition $node, $defaults = true)
+    {
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('change_password')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('form')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('type')->defaultValue('fos_user_change_password')->end()
+                                    ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\ChangePasswordFormType')->end()
+                                    ->scalarNode('name')->defaultValue('fos_user_change_password_form')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                        ->defaultValue(array('ChangePassword', 'Default'))
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('change_password')->defaultValue('RollerworksMultiUserBundle:UserBundle/ChangePassword:changePassword.html.twig')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('change_password')
+                        ->canBeUnset()
+                        ->children()
+                            ->arrayNode('form')
+                                ->children()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('class')->end()
+                                    ->scalarNode('name')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->children()
+                                    ->scalarNode('change_password')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
+    }
+
+    final public function addServiceSection(ArrayNodeDefinition $node, $defaults = true)
+    {
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('service')
+                        ->addDefaultsIfNotSet()
                         ->children()
                             ->scalarNode('mailer')->defaultValue('fos_user.mailer.default')->end()
                             ->scalarNode('email_canonicalizer')->defaultValue('fos_user.util.canonicalizer.default')->end()
@@ -332,58 +608,134 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-            ->end()
-        ;
-    }
-
-    final public function addTemplateSection(ArrayNodeDefinition $node)
-    {
-        $node
-            ->children()
-                ->arrayNode('template')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->scalarNode('engine')->defaultValue('twig')->end()
-                        ->scalarNode('layout')->defaultValue('RollerworksMultiUserBundle::layout.html.twig')->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('service')
+                        ->children()
+                            ->scalarNode('mailer')->end()
+                            ->scalarNode('email_canonicalizer')->end()
+                            ->scalarNode('username_canonicalizer')->end()
+                            ->scalarNode('user_manager')->end()
+                        ->end()
                     ->end()
                 ->end()
-            ->end()
-        ;
+            ;
+        }
     }
 
-    final public function addGroupSection(ArrayNodeDefinition $node)
+    final public function addTemplateSection(ArrayNodeDefinition $node, $defaults = true)
     {
-        $node
-            ->children()
-                ->arrayNode('group')
-                    ->canBeUnset()
-                    ->children()
-                        ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
-                        ->scalarNode('group_manager')->defaultValue('fos_user.group_manager.default')->end()
-                        ->arrayNode('form')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('type')->defaultValue('fos_user_group')->end()
-                                ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\GroupFormType')->end()
-                                ->scalarNode('name')->defaultValue('fos_user_group_form')->end()
-                                ->arrayNode('validation_groups')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array('Registration', 'Default'))
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('template')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('engine')->defaultValue('twig')->end()
+                            ->scalarNode('layout')->defaultValue('RollerworksMultiUserBundle::layout.html.twig')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('template')
+                        ->children()
+                            ->scalarNode('engine')->end()
+                            ->scalarNode('layout')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+        }
+    }
+
+    final public function addGroupSection(ArrayNodeDefinition $node, $defaults = true)
+    {
+        if ($defaults) {
+            $node
+                ->children()
+                    ->arrayNode('group')
+                        ->canBeUnset()
+                        ->children()
+                            ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
+                            ->scalarNode('group_manager')->defaultValue('fos_user.group_manager.default')->end()
+                            ->arrayNode('form')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('type')->defaultValue('fos_user_group')->end()
+                                    ->scalarNode('class')->defaultValue('FOS\UserBundle\Form\Type\GroupFormType')->end()
+                                    ->scalarNode('name')->defaultValue('fos_user_group_form')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                        ->defaultValue(array('Registration', 'Default'))
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('edit')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:edit.html.twig')->end()
+                                    ->scalarNode('list')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:list.html.twig')->end()
+                                    ->scalarNode('new')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:new.html.twig')->end()
+                                    ->scalarNode('show')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:show.html.twig')->end()
                                 ->end()
                             ->end()
                         ->end()
-                        ->arrayNode('template')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('edit')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:edit.html.twig')->end()
-                                ->scalarNode('list')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:list.html.twig')->end()
-                                ->scalarNode('new')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:new.html.twig')->end()
-                                ->scalarNode('show')->defaultValue('RollerworksMultiUserBundle:UserBundle/Group:show.html.twig')->end()
+                    ->end()
+                ->end()
+            ;
+        } else {
+            $node
+                ->children()
+                    ->arrayNode('group')
+                        ->canBeUnset()
+                        ->children()
+                            ->scalarNode('group_class')->end()
+                            ->scalarNode('group_manager')->end()
+                            ->arrayNode('form')
+                                ->children()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('class')->end()
+                                    ->scalarNode('name')->end()
+                                    ->arrayNode('validation_groups')
+                                        ->prototype('scalar')->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('template')
+                                ->children()
+                                    ->scalarNode('edit')->end()
+                                    ->scalarNode('list')->end()
+                                    ->scalarNode('new')->end()
+                                    ->scalarNode('show')->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()
                 ->end()
-            ->end()
-        ;
+            ;
+        }
+    }
+
+    private function convertArrayToBitmask($enableServices)
+    {
+        $availableSections = array('profile', 'change_password', 'registration', 'resetting', 'group');
+        $enableServicesMask = self::CONFIG_ALL ^ self::CONFIG_SECTION_PROFILE ^ self::CONFIG_SECTION_CHANGE_PASSWORD ^ self::CONFIG_SECTION_REGISTRATION ^ self::CONFIG_SECTION_RESETTING ^ self::CONFIG_SECTION_GROUP;
+
+        foreach ($enableServices as $enableService) {
+            if (!in_array($enableService, $availableSections)) {
+                throw new \InvalidArgumentException(sprintf('Unable to add unknown configuration-section "%s".', $serviceName));
+            }
+
+            $enableServicesMask |= constant(__CLASS__ . '::CONFIG_SECTION_' . strtoupper($enableService));
+        }
+
+        $enableServices = $enableServicesMask;
+
+        return $enableServices;
     }
 }

--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
@@ -50,7 +50,7 @@ class UserServicesFactory
 
             $node = $configTree->root('user');
             $configuration = new Configuration();
-            $configuration->addUserConfig($node);
+            $configuration->addUserSysConfig($node);
 
             self::$configTree = $configTree;
         }

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\DependencyInjection;
+
+use Rollerworks\Bundle\MultiUserBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessedValueContainsAreAllEmptyByDefault()
+    {
+        $this->assertProcessedConfigurationEquals(array(), array());
+    }
+
+    public function testProcessedValuesRespectOriginalValues()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                array(
+                    'path' => '/',
+                    'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+
+                    'profile' => false,
+                    'registration' => false,
+                    'resetting' => false,
+                    'change_password' => false,
+                ),
+                array(
+                    'path' => '/user',
+                ),
+            ),
+            array(
+                'path' => '/user',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+            )
+        );
+    }
+
+    public function testConfigurationAllSectionsEnabledByDefault()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                array(
+                    'path' => '/',
+                    'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                    'profile' => array(),
+                    'change_password' => array(),
+                    'registration' => array(),
+                    'resetting' => array(),
+                    'group' => array(),
+                    'security' => array(),
+                    'template' => array(),
+                ),
+            ),
+            array(
+                'path' => '/',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                'profile' => array(),
+                'change_password' => array(),
+                'registration' => array(),
+                'resetting' => array(),
+                'group' => array(),
+                'security' => array(),
+                'template' => array(),
+            )
+        );
+    }
+
+    public function testConfigurationBCLayer()
+    {
+        $this->assertProcessedConfigurationEquals(
+            array(
+                array(
+                    'path' => '/',
+                    'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                    'profile' => array(),
+                    'change_password' => array(),
+                    'registration' => array(),
+                    'security' => array(),
+                    'template' => array(),
+                ),
+            ),
+            array(
+                'path' => '/',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                'profile' => array(),
+                'change_password' => array(),
+                'registration' => array(),
+                'security' => array(),
+                'template' => array(),
+            ),
+            array('profile', 'change_password', 'registration')
+        );
+
+        $this->assertConfigurationIsInvalid(
+            array(
+                array(
+                    'path' => '/',
+                    'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                    'profile' => array(),
+                    'change_password' => array(),
+                    'registration' => array(),
+                    'security' => array(),
+                    'template' => array(),
+                    'resetting' => array(),
+                ),
+            ),
+            array('profile', 'change_password', 'registration'),
+            'Unrecognized options "resetting" under "user"'
+        );
+    }
+
+    public function testConfigurationRequiresSectionEnabled()
+    {
+        $this->assertConfigurationIsInvalid(
+            array(
+                array(
+                    'path' => '/',
+                    'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+
+                    'profile' => array(),
+                ),
+                array(
+                    'path' => '/user',
+                ),
+            ),
+            Configuration::CONFIG_ALL ^ Configuration::CONFIG_SECTION_PROFILE,
+            'Unrecognized options "profile" under "user"'
+        );
+    }
+
+    /**
+     * @dataProvider getConfigs
+     */
+    public function testConfigurationSectionGetsEnabled($section, $config, $message = null, $enableServices = null)
+    {
+        if (null === $enableServices) {
+            $enableServices = constant('Rollerworks\Bundle\MultiUserBundle\DependencyInjection\Configuration::CONFIG_SECTION_' . strtoupper($section));
+            $message = 'Unrecognized options "'.$section.'" under "user"';
+        }
+
+        $this->assertProcessedConfigurationEquals(
+            array(
+                $config
+            ),
+            $config,
+            $enableServices
+        );
+
+        $this->assertConfigurationIsInvalid(
+            array(
+                $config
+            ),
+            Configuration::CONFIG_ALL ^ $enableServices,
+            $message
+        );
+    }
+
+    public static function getConfigs()
+    {
+        return array(
+            array('profile', array('profile' => array())),
+            array('change_password', array('change_password' => array())),
+            array('registration', array('registration' => array())),
+            array('resetting', array('resetting' => array())),
+            array('group', array('group' => array())),
+
+            array('db_driver', array('db_driver' => 'orm'), 'Unrecognized options "db_driver" under "user"', Configuration::CONFIG_DB_DRIVER),
+            array('request_matcher', array('request_matcher' => ''), 'Unrecognized options "request_matcher" under "user"', Configuration::CONFIG_REQUEST_MATCHER),
+            array('path', array('path' => ''), 'Unrecognized options "path" under "user"', Configuration::CONFIG_REQUEST_MATCHER),
+            array('host', array('host' => ''), 'Unrecognized options "host" under "user"', Configuration::CONFIG_REQUEST_MATCHER),
+            array('user_class', array('user_class' => 'stdClass'), 'Unrecognized options "user_class" under "user"', Configuration::CONFIG_USER_CLASS),
+        );
+    }
+
+    /**
+     * @param integer|array $enableServices
+     *
+     * @return ArrayNodeDefinition|NodeDefinition
+     */
+    protected function getTreeBuilderRoot($enableServices = Configuration::CONFIG_ALL)
+    {
+        $configuration = new Configuration();
+
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('user');
+        $configuration->addUserConfig($rootNode, $enableServices);
+
+        return $rootNode;
+    }
+
+    /**
+     * Assert that the given configuration values are invalid.
+     *
+     * Optionally provide (part of) the exception message that you expect to receive.
+     *
+     * @param array       $configurationValues
+     * @param integer     $enableServices
+     * @param string|null $expectedMessage
+     */
+    protected function assertConfigurationIsInvalid(array $configurationValues, $enableServices = Configuration::CONFIG_ALL, $expectedMessage = null)
+    {
+        self::assertThat(
+            $configurationValues,
+            new ConfigurationValuesAreInvalidConstraint(
+                $this->getTreeBuilderRoot($enableServices),
+                $expectedMessage
+            )
+        );
+    }
+
+    /**
+     * Assert that the given configuration values, when processed, will equal to the given array
+     *
+     * @param array   $configurationValues
+     * @param array   $expectedProcessedConfiguration
+     * @param integer $enableServices
+     */
+    protected function assertProcessedConfigurationEquals(array $configurationValues, array $expectedProcessedConfiguration, $enableServices = Configuration::CONFIG_ALL) {
+        self::assertThat(
+            $expectedProcessedConfiguration,
+            new ProcessedConfigurationEqualsConstraint(
+                $this->getTreeBuilderRoot($enableServices),
+                $configurationValues
+            )
+        );
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ConfigurationValuesAreInvalidConstraint.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ConfigurationValuesAreInvalidConstraint.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationConstraint;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConstraint
+{
+    private $expectedMessage;
+
+    public function __construct(NodeDefinition $configuration, $expectedMessage = null)
+    {
+        $this->expectedMessage = $expectedMessage;
+        $this->configuration = $configuration;
+    }
+
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        $this->validateConfigurationValuesArray($other);
+
+        try {
+            $this->processConfiguration($other);
+        } catch (InvalidConfigurationException $exception) {
+            return $this->evaluateException($exception, $description, $returnResult);
+        }
+
+        if ($returnResult) {
+            return false;
+        }
+
+        $this->fail($other, $description);
+    }
+
+    public function toString()
+    {
+        $toString = 'is invalid for the given configuration';
+
+        if ($this->expectedMessage !== null) {
+            $toString .= ' (expected exception message: '.$this->expectedMessage.')';
+        }
+
+        return $toString;
+    }
+
+    private function evaluateException(\Exception $exception, $description, $returnResult)
+    {
+        if ($this->expectedMessage === null) {
+            return true;
+        }
+
+        // reuse the exception message constraint from PHPUnit itself
+        $constraint = new \PHPUnit_Framework_Constraint_ExceptionMessage($this->expectedMessage);
+
+        return $constraint->evaluate($exception, $description, $returnResult);
+    }
+
+    protected function processConfiguration(array $configurationValues)
+    {
+        $processor = new Processor();
+
+        return $processor->process($this->configuration->end()->buildTree(), $configurationValues);
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ProcessedConfigurationEqualsConstraint.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/ProcessedConfigurationEqualsConstraint.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationConstraint;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Processor;
+
+class ProcessedConfigurationEqualsConstraint extends AbstractConfigurationConstraint
+{
+    private $configurationValues;
+
+    public function __construct(NodeDefinition $configuration, array $configurationValues)
+    {
+        $this->validateConfigurationValuesArray($configurationValues);
+        $this->configurationValues = $configurationValues;
+        $this->configuration = $configuration;
+    }
+
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        $processedConfiguration = $this->processConfiguration($this->configurationValues);
+
+        $constraint = new \PHPUnit_Framework_Constraint_IsEqual($other);
+
+        return $constraint->evaluate($processedConfiguration, '', $returnResult);
+    }
+
+    public function toString()
+    {
+        // won't be used, this constraint only wraps \PHPUnit_Framework_Constraint_IsEqual
+    }
+
+    protected function processConfiguration(array $configurationValues)
+    {
+        $processor = new Processor();
+
+        return $processor->process($this->configuration->end()->buildTree(), $configurationValues);
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/DependencyInjection/AcmeAdminExtension.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/DependencyInjection/AcmeAdminExtension.php
@@ -22,6 +22,9 @@ class AcmeAdminExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $config);
+
         $factory = new UserServicesFactory($container);
         $factory->create('acme_admin', array(
             array(
@@ -68,7 +71,8 @@ class AcmeAdminExtension extends Extension
                         'change_password' => 'AcmeAdminBundle:ChangePassword:changePassword.html.twig',
                     )
                 ),
-            )
+            ),
+            $config
         ));
     }
 }

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the RollerworksMultiUserBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollerworks\Bundle\MultiUserBundle\Tests\Functional\Bundle\AdminBundle\DependencyInjection;
+
+use Rollerworks\Bundle\MultiUserBundle\DependencyInjection\Configuration as UserConfiguration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('acme_admin');
+
+        $configuration = new UserConfiguration();
+        $configuration->addUserConfig($rootNode, array('profile', 'change_password', 'registration', 'resetting', 'group'), false);
+
+        return $treeBuilder;
+    }
+}

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -78,4 +78,65 @@ class ResettingControllerTest extends WebTestCaseFunctional
         $client->submit($form);
         $this->assertTrue($client->getResponse()->isRedirect('/admin/profile/'));
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+//    public function testResettingAdminWithNoRegistration()
+//    {
+//        $client = self::newClient(array('config' => 'admin_no_reg.yml'));
+//        $client->insulate(); // runInSeparateProcess fails with an fatal error so we use this instead.
+//        $client->enableProfiler();
+//
+//        $client->getContainer()->get('rollerworks_multi_user.user_discriminator')->setCurrentUser('acme_admin');
+//
+//        /** @var \FOS\UserBundle\Model\UserManagerInterface $userManager */
+//        $userManager = $client->getContainer()->get('acme_admin.user_manager');
+//
+//        $admin = $userManager->createUser();
+//        $admin
+//            ->setUsername('dummy-example')
+//            ->setEmail('dummy-example@example.com')
+//            ->setPlainPassword('mySecret0Password')
+//        ;
+//
+//        $userManager->updateUser($admin);
+//
+//        $crawler = $client->request('GET', '/admin/resetting/request');
+//        $this->assertEquals($crawler->filter('form')->count(), 1);
+//
+//        $form = $crawler->selectButton('Reset password')->form();
+//        $form['username'] = 'dummy-example';
+//
+//        $client->submit($form);
+//        $this->assertTrue($client->getResponse()->isRedirect('/admin/resetting/check-email?email=...%40example.com'));
+//
+//        $mailCollector = $client->getProfile()->getCollector('swiftmailer');
+//
+//        // Check that an e-mail was sent
+//        $this->assertEquals(1, $mailCollector->getMessageCount());
+//
+//        $collectedMessages = $mailCollector->getMessages('default');
+//        $message = $collectedMessages[0];
+//
+//        // Asserting that the correct URL is used
+//        $this->assertInstanceOf('Swift_Message', $message);
+//        $this->assertRegExp('{To reset your password - please visit http://[^/]+/admin/resetting/reset/[^\s]+}i', $message->getBody());
+//
+//        if (preg_match('{To reset your password - please visit http://[^/]+/admin/resetting/reset/([^\s]+)}i', $message->getBody(), $match) < 0) {
+//            $this->fail('Regex did not match email message: ' . $message->getBody());
+//        }
+//
+//        $token = $match[1];
+//
+//        $crawler = $client->request('GET', '/admin/resetting/reset/' . $token);
+//        $this->assertEquals($crawler->filter('form')->count(), 1);
+//
+//        $form = $crawler->selectButton('Change password')->form();
+//        $form['acme_admin_resetting_form[plainPassword][first]'] = 'mySecret0Password';
+//        $form['acme_admin_resetting_form[plainPassword][second]'] = 'mySecret0Password';
+//
+//        $client->submit($form);
+//        $this->assertTrue($client->getResponse()->isRedirect('/admin/profile/'));
+//    }
 }

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/admin_no_reg.yml
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/admin_no_reg.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: admin.yml }
+
+acme_admin:
+    registration: false

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/framework.yml
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/Functional/config/framework.yml
@@ -24,11 +24,8 @@ monolog:
     handlers:
         main:
             type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
+            path:  %kernel.cache_dir%/../%kernel.environment%.log
             level: debug
-        firephp:
-            type:  firephp
-            level: info
 
 swiftmailer:
     transport: mail


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | yes |
| BC Breaks? | nnp |
| Deprecations? | yes |
| Tests Pass? | yes |
| Fixed Tickets | GH-53 |

This changes the enabling of options to use a bitmask (instead of array)
which is much easier to work with. The old method is still supported

And fixes the overwriting configurations (which were overwriting
due to the defaulting)

Last this adds a more fine grained base-configuration enabling.
