### PR TITLE
Improve the UserServicesFactory Form default handling

### DIFF
--- a/docs/overriding_forms.md
+++ b/docs/overriding_forms.md
@@ -45,6 +45,7 @@ class AcmeUserExtension extends Extension
                     'form' => array(
                         'type' => 'acme_user_registration',
                         'class' => 'Acme\UserBundle\Form\Type\RegistrationFormType',
+                        'name' => 'acme_user_registration_form',
                     )
                 )
             )

--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/Factory/UserServicesFactory.php
@@ -244,10 +244,13 @@ class UserServicesFactory
 
     protected function convertFormType(ContainerBuilder $container, $type, array $config, $modelRef = null)
     {
-        if ('fos_user_' . $type === $config['type'] || 'FOS\\UserBundle\\Form\\Type\\' === substr($config['class'], 0, 25) || 'fos_user_' . $type . '_form' === $config['name']) {
+        if ('fos_user_' . $type === $config['type'] && 'FOS\\UserBundle\\Form\\Type\\' !== substr($config['class'], 0, 25)) {
+            throw new \RuntimeException(sprintf('Form type "%s" uses the "fos_user_" prefix with a custom class. Please overwrite the getName() method to return a unique name.', $config['type']));
+        }
+
+        if ('fos_user_' . $type === $config['type'] || 'FOS\\UserBundle\\Form\\Type\\' === substr($config['class'], 0, 25)) {
             $config['type'] = sprintf('%s_%s',  $this->servicePrefix, $type);
             $config['class'] = 'Rollerworks\\Bundle\\MultiUserBundle\Form\\Type\\' . join('', array_slice(explode('\\', $config['class']), -1));
-            $config['name'] = sprintf('%s_%s_form',  $this->servicePrefix, $type);
 
             $container->setDefinition(sprintf('%s.%s.form.type', $this->servicePrefix, $type), new Definition($config['class']))
                 ->setTags(array('form.type' => array(array('alias' => $config['type']))))
@@ -255,6 +258,10 @@ class UserServicesFactory
                 ->addArgument($config['type']);
 
             $config['class'] = null;
+        }
+
+        if ('fos_user_' . $type . '_form' === $config['name']) {
+            $config['name'] = sprintf('%s_%s_form',  $this->servicePrefix, $type);
         }
 
         return $config;

--- a/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
+++ b/tests/Rollerworks/Bundle/MultiUserBundle/Tests/DependencyInjection/UserServicesFactoryTest.php
@@ -756,6 +756,70 @@ class UserServicesFactoryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testInvalidFormConfiguration()
+    {
+        $factory = new UserServicesFactory($this->containerBuilder);
+
+        $config = array(
+            array(
+                'path' => '/',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                'services_prefix' => 'acme_user',
+                'routes_prefix' => 'acme_user',
+
+                'profile' => false,
+                'resetting' => false,
+                'change_password' => false,
+                'registration' => array(
+                    'form' => array(
+                        'type' => 'fos_user_registration',
+                        'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type\RegistrationFormType',
+                    )
+                ),
+            )
+        );
+
+        $this->setExpectedException('RuntimeException', 'Form type "fos_user_registration" uses the "fos_user_" prefix with a custom class. Please overwrite the getName() method to return a unique name.');
+
+        $factory->create('acme', $config);
+    }
+
+    public function testFormNameIsChangedWhenDefault()
+    {
+        $factory = new UserServicesFactory($this->containerBuilder);
+
+        $config = array(
+            array(
+                'path' => '/',
+                'user_class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\User',
+                'services_prefix' => 'acme_user',
+                'routes_prefix' => 'acme_user',
+
+                'profile' => false,
+                'resetting' => false,
+                'change_password' => false,
+                'registration' => array(
+                    'form' => array(
+                        'type' => 'acme_user_registration',
+                        'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type\RegistrationFormType',
+                    )
+                ),
+            )
+        );
+
+        $factory->create('acme', $config);
+
+        $def = $this->containerBuilder->getDefinition('rollerworks_multi_user.user_system.acme');
+        $expected = array(
+            'class' => 'Rollerworks\Bundle\MultiUserBundle\Tests\Stub\Form\Type\RegistrationFormType',
+            'type' => 'acme_user_registration',
+            'name' => 'acme_user_registration_form',
+            'validation_groups' => array('Registration', 'Default'),
+        );
+
+        $this->assertFormDefinitionEqual($expected, 'acme_user', 'registration', $def);
+    }
+
     public static function provideModelManagerConfigs()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets |  |

Related to GH-55 GH-56

This improves the UserServicesFactory Form default handling
- Detect if a custom class is used with the default fos form-type
- Change 'only' the name when it uses the fos_user prefix

This removes the requirement to set the class, type and the name.
And fixes an edge case where only the name uses the fos_user prefix

And updates the documentation, which was missing the name in the example.
