### PR TITLE
Removed template engine from configuration

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/RollerworksMultiUserExtension.php
+++ b/src/Rollerworks/Bundle/MultiUserBundle/DependencyInjection/RollerworksMultiUserExtension.php
@@ -61,9 +61,6 @@ class RollerworksMultiUserExtension extends Extension implements PrependExtensio
             'firewall_name' => 'dummy',
             'user_class' => 'Acme\UserBundle\Entity\User',
             'from_email' => $config['from_email'],
-            'template' => array(
-                'engine' => $config['template']['engine'],
-            ),
             'registration' => array(
                 'confirmation' => array(
                     'enabled' => false,


### PR DESCRIPTION
This is needed to conform the new FOSUserBundle 2.0 configuration as mentioned by @djaed on #68 
