### PR TITLE
Fix errors translation of security login page

### DIFF
--- a/src/Rollerworks/Bundle/MultiUserBundle/Resources/views/UserBundle/Security/login.html.twig
+++ b/src/Rollerworks/Bundle/MultiUserBundle/Resources/views/UserBundle/Security/login.html.twig
@@ -4,7 +4,7 @@
 
 {% block fos_user_content %}
 {% if error %}
-    <div>{{ error|trans }}</div>
+    <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
 {% endif %}
 
 <form action="{{ path(rollerworks_multi_user_user().getRoutePrefix() ~ "_security_check") }}" method="post">


### PR DESCRIPTION
Current translation show exception dump on error. This should take care of it.
